### PR TITLE
ensure that this script works for both owners of apps as well as collaborators

### DIFF
--- a/scripts/codeship_heroku_check_access
+++ b/scripts/codeship_heroku_check_access
@@ -10,5 +10,5 @@ trap error_message ERR
 
 set -e
 
-heroku apps -A -p | grep -e "^${HEROKU_APP_NAME}\s"
+heroku apps -A -p | grep -e "^${HEROKU_APP_NAME}\b"
 echo -e "\e[32mThe application \"${HEROKU_APP_NAME}\" can be accessed.\e[39m"


### PR DESCRIPTION
Fixes #19

Ensure that this script works for both owners of apps as well as collaborators by checking for word-break instead of space in the `grep` command [`\s` only matches spaces, but `\b` matches any word break (e.g., whitespace as well as end-of-line)].
