### PR TITLE
Switch to using `heroku apps:info` for checking access

### DIFF
--- a/scripts/codeship_heroku_check_access
+++ b/scripts/codeship_heroku_check_access
@@ -1,6 +1,5 @@
 #!/bin/bash
 # Check access to a Heroku application via the Heroku toolbelt
-
 HEROKU_APP_NAME=${1:?'You need to provide the application name as the second parameter'}
 
 function error_message() {
@@ -10,5 +9,5 @@ trap error_message ERR
 
 set -e
 
-heroku apps -A -p | grep -e "^${HEROKU_APP_NAME}\s"
+heroku apps:info "${HEROKU_APP_NAME}"
 echo -e "\e[32mThe application \"${HEROKU_APP_NAME}\" can be accessed.\e[39m"


### PR DESCRIPTION
This brings the check in line with the current version we use for the integrated deployment on the Codeship Classic Infrastructure.

Closes #19
