### PR TITLE
Update to the latest versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM debian:jessie
 LABEL maintainer maintainers@codeship.com
 
 ENV \
-  CACHE_BUST=1 \
+  CACHE_BUST=2 \
   JQ_VERSION="1.5" \
   PATH="/usr/local/heroku/bin:$PATH"
 

--- a/dockercfg-generator/Dockerfile
+++ b/dockercfg-generator/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker:1.13
+FROM docker:stable
 LABEL maintainer maintainers@codeship.com
 
 COPY heroku_docker_creds.sh /usr/local/bin/

--- a/dockercfg-generator/Dockerfile.test
+++ b/dockercfg-generator/Dockerfile.test
@@ -1,4 +1,4 @@
-FROM alpine:3.5
+FROM alpine:latest
 LABEL maintainer maintainers@codeship.com
 
 RUN \


### PR DESCRIPTION
I've updated the `dockercfg` generator to use the latest _stable_ Docker version (currently 17.03). Not sure if we should instead use the version we're currently using in production instead.

I'm also thinking about disabling caching for the Heroku deployment container, which would allow us to remove the `CACHE_BUST` environment variable and simply rebuild the container on each build.