### PR TITLE
Updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM debian:jessie
-LABEL maintainer maintainers@codeship.com
+LABEL maintainer='Codeship Inc., <maintainers@codeship.com>'
 
 ENV CACHE_BUST='2017-08-07' \
     JQ_VERSION='1.5' \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,9 @@
 FROM debian:jessie
 LABEL maintainer maintainers@codeship.com
 
-ENV \
-  CACHE_BUST=1 \
-  JQ_VERSION="1.5" \
-  PATH="/usr/local/heroku/bin:$PATH"
+ENV CACHE_BUST='2017-08-07' \
+    JQ_VERSION='1.5' \
+    PATH="/usr/local/heroku/bin:${PATH}"
 
 RUN \
   apt-get update && \

--- a/dockercfg-generator/Dockerfile
+++ b/dockercfg-generator/Dockerfile
@@ -1,5 +1,5 @@
 FROM docker:17.06.0
-LABEL maintainer maintainers@codeship.com
+LABEL maintainer='Codeship Inc., <maintainers@codeship.com>'
 
 COPY heroku_docker_creds.sh /usr/local/bin/
 RUN chmod u+x /usr/local/bin/heroku_docker_creds.sh

--- a/dockercfg-generator/Dockerfile
+++ b/dockercfg-generator/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker:17.06.0
+FROM docker:17.05.0
 LABEL maintainer='Codeship Inc., <maintainers@codeship.com>'
 
 COPY heroku_docker_creds.sh /usr/local/bin/

--- a/dockercfg-generator/Dockerfile
+++ b/dockercfg-generator/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker:1.13
+FROM docker:17.06.0
 LABEL maintainer maintainers@codeship.com
 
 COPY heroku_docker_creds.sh /usr/local/bin/

--- a/dockercfg-generator/Dockerfile.test
+++ b/dockercfg-generator/Dockerfile.test
@@ -1,4 +1,4 @@
-FROM alpine:3.5
+FROM alpine:3.6
 LABEL maintainer='Codeship Inc., <maintainers@codeship.com>'
 
 RUN \

--- a/dockercfg-generator/Dockerfile.test
+++ b/dockercfg-generator/Dockerfile.test
@@ -1,5 +1,5 @@
 FROM alpine:3.5
-LABEL maintainer maintainers@codeship.com
+LABEL maintainer='Codeship Inc., <maintainers@codeship.com>'
 
 RUN \
   echo "Hello Container Registry at $(date)" > hello.txt && \


### PR DESCRIPTION
* Update the `dockercfg` generator to use Docker v17.05 (same version as used on the build VMs right now)
* Build a new image of the deployment container.
* Update the “maintainer” label
* Update the test Docker image to use alpine:3.6 as base image