### PR TITLE
update of Heroku CLI to version 7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ RUN \
     bash \
     ca-certificates \
     sudo \
+    curl \
     wget && \
   apt-get clean -y && \
   rm -rf /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM debian:jessie
 LABEL maintainer='Codeship Inc., <maintainers@codeship.com>'
 
-ENV CACHE_BUST='2018-04-06' \
+ENV CACHE_BUST='2018-06-11' \
     PATH="/usr/local/heroku/bin:${PATH}"
 
 RUN \


### PR DESCRIPTION
Users reporting inability to utilize new features.

Current:

```
docker run --rm -it codeship/heroku-deployment heroku version
heroku-cli/6.99.0-ec9edad (linux-x64) node-v9.11.1
```

With change:

```
docker run --rm -it dkcodeship/new-heroku-deployment heroku version
heroku/7.0.91 linux-x64 node-v10.4.0
```
