### PR TITLE
Update heroku_docker_creds.sh

### DIFF
--- a/dockercfg-generator/heroku_docker_creds.sh
+++ b/dockercfg-generator/heroku_docker_creds.sh
@@ -4,9 +4,11 @@ set -e
 
 echo 'Heroku Registry dockercfg generator'
 
-: "${HEROKU_API_KEY:?Need to set your HEROKU_API_KEY}"
+# If $HEROKU_API_KEY value is present, set to $CODESHIP_HEROKU_API_KEY
+[[ ! -z "${HEROKU_API_KEY}" ]] && CODESHIP_HEROKU_API_KEY=${HEROKU_API_KEY}
+: "${CODESHIP_HEROKU_API_KEY:?Need to set your CODESHIP_HEROKU_API_KEY}"
 
 DOCKER_USERNAME="_" \
-DOCKER_PASSWORD="${HEROKU_API_KEY}" \
+DOCKER_PASSWORD="${CODESHIP_HEROKU_API_KEY}" \
 DOCKER_REGISTRY="registry.heroku.com" \
 /bin/docker_creds.sh "${1}"


### PR DESCRIPTION
steer usage from $HEROKU_API_KEY to $CODESHIP_HEROKU_API_KEY, to be in alignment with [Heroku platform env vars](https://github.com/codeship-library/heroku-deployment/blob/master/deployment/scripts/codeship_heroku_deploy)