### PR TITLE
Implements flag to reset git checkout to a clean state

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ ENV CACHE_BUST='2018-08-24' \
 RUN \
   apt-get update && \
   apt-get install -y --no-install-recommends \
+    git \
     bash \
     ca-certificates \
     sudo \

--- a/Dockerfile.ansible
+++ b/Dockerfile.ansible
@@ -2,7 +2,7 @@ FROM ubuntu:14.04
 
 RUN \
   apt-get update && \
-  apt-get install -y --no-install-recommends python-setuptools apt-transport-https ca-certificates wget rsync && \
+  apt-get install -y --no-install-recommends python-setuptools apt-transport-https ca-certificates wget rsync git && \
   easy_install pip==9.0.3 && \
   pip install ansible==2.4.0.0 pyasn1==0.3.6 ndg-httpsclient==0.4.3 urllib3==1.22 pyOpenSSL==17.3.0
 

--- a/codeship-steps.yml
+++ b/codeship-steps.yml
@@ -1,6 +1,6 @@
 - name: Turn /app folder into git repository for tests
   service: heroku_on_ansible
-  command: cd /app && git init && git commit -m 'foo'
+  command: bash -c 'cd /app && git init && git commit -m "foo"'
 - name: Deployment Test via Ansible Container
   service: heroku_on_ansible
   command: codeship_heroku_deploy -f /app -N codeship-test-ruby-app

--- a/codeship-steps.yml
+++ b/codeship-steps.yml
@@ -10,6 +10,12 @@
 - name: Deployment Test via Ansible Container with a failing URL check
   service: heroku_on_ansible
   command: bash -c "! codeship_heroku_deploy -f /app -N codeship-test-ruby-app -c -u http://foo.bar.baz"
+- name: Deployment via Ansible Container with changes in repository being reset
+  service: heroku_on_ansible
+  command: bash -c "echo 'foo' > /app/web.rb && codeship_heroku_deploy -f /app -N codeship-test-ruby-app -C -c"
+- name: Negative check for previous test - url check should not succeed if web.rb contains no ruby and repository cleanup is not configured
+  service: heroku_on_ansible
+  command: bash -c "echo 'foo' > /app/web.rb && ! codeship_heroku_deploy -f /app -N codeship-test-ruby-app -c"
 - name: Make sure that files are executable in "legacy paths"
   service: heroku_on_ansible
   command: bash -c 'test -x "$(which check_access_to_heroku_app)" && test -x "$(which heroku_run)"'

--- a/codeship-steps.yml
+++ b/codeship-steps.yml
@@ -1,6 +1,6 @@
 - name: Turn /app folder into git repository for tests
   service: heroku_on_ansible
-  command: bash -c 'cd /app && git init && git commit -m "foo"'
+  command: bash -c 'cd /app && git config --global user.email "you@example.com" && git config --global user.name "Your Name" && git init && git commit -m "foo"'
 - name: Deployment Test via Ansible Container
   service: heroku_on_ansible
   command: codeship_heroku_deploy -f /app -N codeship-test-ruby-app

--- a/codeship-steps.yml
+++ b/codeship-steps.yml
@@ -1,6 +1,6 @@
 - name: Turn /app folder into git repository for tests
   service: heroku_on_ansible
-  command: bash -c 'cd /app && git config --global user.email "you@example.com" && git config --global user.name "Your Name" && git init && git commit -m "foo"'
+  command: bash -c 'cd /app && git config --global user.email "you@example.com" && git config --global user.name "Your Name" && git init && git add . && git commit -m "foo"'
 - name: Deployment Test via Ansible Container
   service: heroku_on_ansible
   command: codeship_heroku_deploy -f /app -N codeship-test-ruby-app

--- a/codeship-steps.yml
+++ b/codeship-steps.yml
@@ -1,3 +1,6 @@
+- name: Turn /app folder into git repository for tests
+  service: heroku_on_ansible
+  command: cd /app && git init && git commit -m 'foo'
 - name: Deployment Test via Ansible Container
   service: heroku_on_ansible
   command: codeship_heroku_deploy -f /app -N codeship-test-ruby-app

--- a/deployment/scripts/codeship_heroku_deploy
+++ b/deployment/scripts/codeship_heroku_deploy
@@ -37,10 +37,13 @@ EOF
 function check_url {
   local tries=6
   local status=0
+  local wait=5
   local cmd="wget --no-check-certificate --output-document=/dev/null ${1}"
 
+  sleep ${wait}
+
   for (( i = 1; i <=${tries}; i++ )); do
-    echo -e "\e[0;36mTrying ($i of ${TRIES}) '${cmd}'\e[0m"
+    echo -e "\e[0;36mTrying ($i of ${tries}) '${cmd}'\e[0m"
     ${cmd}
     status=$?
 
@@ -55,10 +58,10 @@ function check_url {
       status=0
     fi
 
-    if [ $i -lt ${TRIES} ]; then
-      echo -e "\e[0;36mWaiting ${WAIT} seconds before trying again.\e[0m"
+    if [ $i -lt ${tries} ]; then
+      echo -e "\e[0;36mWaiting ${wait} seconds before trying again.\e[0m"
       echo "------------------------------------------------------------------------------------------------------"
-      sleep "${WAIT}"
+      sleep "${wait}"
     fi
   done
 

--- a/deployment/scripts/codeship_heroku_deploy
+++ b/deployment/scripts/codeship_heroku_deploy
@@ -10,6 +10,7 @@ CODESHIP_HEROKU_DEPLOY_FOLDER=${CODESHIP_HEROKU_DEPLOY_FOLDER:-"${PWD}"}
 CODESHIP_HEROKU_POST_DEPLOY_COMMAND=${CODESHIP_HEROKU_POST_DEPLOY_COMMAND:-""}
 CODESHIP_HEROKU_URL=${CODESHIP_HEROKU_URL:-""}
 CODESHIP_HEROKU_CHECK_APP_URL=${CODESHIP_HEROKU_CHECK_APP_URL:-false}
+CODESHIP_HEROKU_CLEAN_DEPLOY=${CODESHIP_HEROKU_CLEAN_DEPLOY:-false}
 
 SCRIPT_DIRECTORY="$( cd "$(dirname "$0")" ; pwd -P )"
 
@@ -27,6 +28,7 @@ optional:
 -d or CODESHIP_HEROKU_POST_DEPLOY_COMMAND: one-off command to run after deployment
 -u or CODESHIP_HEROKU_URL: url running the service (to use in conjunction with -c)
 -c or CODESHIP_HEROKU_CHECK_APP_URL: check url if service is running after deployment [true/false]
+-C or CODESHIP_HEROKU_CLEAN_DEPLOY: get checkout folder back into committed state before deployment [true/false]
 -h: this
 
 EOF
@@ -63,7 +65,7 @@ function check_url {
   return ${status}
 }
 
-while getopts "N:K:f:u:d:ch" opt; do
+while getopts "N:K:f:u:d:chC" opt; do
   case "$opt" in
     N)
       CODESHIP_HEROKU_APP_NAME="$OPTARG"; ;;
@@ -77,6 +79,8 @@ while getopts "N:K:f:u:d:ch" opt; do
       CODESHIP_HEROKU_URL="$OPTARG"; ;;
     c)
       CODESHIP_HEROKU_CHECK_APP_URL=true; ;;
+    C)
+      CODESHIP_HEROKU_CLEAN_DEPLOY=true ;;
     h) help; exit 0 ;;
     *)
       help
@@ -109,6 +113,11 @@ fi
 if ! HEROKU_API_KEY=$CODESHIP_HEROKU_API_KEY "${SCRIPT_DIRECTORY}/codeship_heroku_check_access" "${CODESHIP_HEROKU_APP_NAME}"; then
   echo "could not access heroku app ${CODESHIP_HEROKU_APP_NAME}, exiting" >&2
   exit 1
+fi
+
+if [ "${CODESHIP_HEROKU_CLEAN_DEPLOY}" == "true" ]; then
+  git reset --hard HEAD
+  git clean -f
 fi
 
 #--include-vcs-ignore set for compatibility with Ubuntu 14.04: https://github.com/heroku/heroku-builds/issues/36


### PR DESCRIPTION
Implements `-C` / `CODESHIP_HEROKU_CLEAN_DEPLOY` which will set codeship_heroku_deploy up to run `git reset --hard HEAD` and `git clean -f` before a deploy to bring the repository back into its committed before a deployment.

https://www.pivotaltracker.com/n/projects/1324766/stories/159212063