### PR TITLE
Fix Ansible deprecation warning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM debian:buster
 LABEL maintainer='Codeship Inc., <maintainers@codeship.com>'
 
-ENV CACHE_BUST='2021-05-11' \
+ENV CACHE_BUST='2021-07-16' \
     PATH="/usr/local/heroku/bin:${PATH}"
 
 RUN \

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,7 +11,7 @@
 - name: install heroku package
   apt:
     package: heroku
-    state: installed
+    state: present
 
 - name: create heroku directory
   file:


### PR DESCRIPTION
```
[DEPRECATION WARNING]: State 'installed' is deprecated. Using state 'present'
This feature will be removed in version 2.9. Deprecation warnings can
be disabled by setting deprecation_warnings=False in ansible.cfg.
```